### PR TITLE
Allow multiple subjects and fix Credential expiration date location

### DIFF
--- a/packages/ssi-types/__tests__/uniform-claims.test.ts
+++ b/packages/ssi-types/__tests__/uniform-claims.test.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs'
-import { CredentialMapper, ICredential, IVerifiableCredential } from '../src'
-import { ICredentialSubject } from '../dist'
+import { CredentialMapper, ICredential, IVerifiableCredential, ICredentialSubject } from '../src'
 
 function getFile(path: string) {
   return fs.readFileSync(path, 'utf-8')

--- a/packages/ssi-types/__tests__/uniform-claims.test.ts
+++ b/packages/ssi-types/__tests__/uniform-claims.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs'
 import { CredentialMapper, ICredential, IVerifiableCredential } from '../src'
+import { ICredentialSubject } from '../dist'
 
 function getFile(path: string) {
   return fs.readFileSync(path, 'utf-8')
@@ -14,7 +15,7 @@ describe('Uniform VC claims', () => {
     const jwtVc: IVerifiableCredential = getFileAsJson('packages/ssi-types/__tests__/vc_vp_examples/vp/vp_general.json').verifiableCredential[0]
     jwtVc['exp' as keyof IVerifiableCredential] = (+new Date()).toString()
     const vc = CredentialMapper.toUniformCredential(jwtVc)
-    expect(vc.credentialSubject.expirationDate).toEqual(new Date(parseInt(jwtVc['exp' as keyof IVerifiableCredential] as string)).toISOString())
+    expect(vc.expirationDate).toEqual(new Date(parseInt(jwtVc['exp' as keyof IVerifiableCredential] as string)).toISOString())
   })
 
   it('should set expiration date if exp is present in JWT vc as number', () => {
@@ -22,19 +23,19 @@ describe('Uniform VC claims', () => {
 
     jwtVc['exp' as keyof IVerifiableCredential] = new Date().valueOf()
     const vc = CredentialMapper.toUniformCredential(jwtVc)
-    expect(vc.credentialSubject.expirationDate).toEqual(new Date(jwtVc['exp' as keyof IVerifiableCredential] as string).toISOString())
+    expect(vc.expirationDate).toEqual(new Date(jwtVc['exp' as keyof IVerifiableCredential] as string).toISOString())
   })
 
   it('should throw an error if expiration date and exp are different in JWT vc', () => {
     const jwtVc: IVerifiableCredential = getFileAsJson('packages/ssi-types/__tests__/vc_vp_examples/vp/vp_general.json').verifiableCredential[0]
     jwtVc['exp' as keyof IVerifiableCredential] = (+new Date()).toString()
-    ;(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).credentialSubject.expirationDate = (+new Date(
+    ;(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).expirationDate = (+new Date(
       (jwtVc['exp' as keyof IVerifiableCredential] as string) + 2
     )).toString()
     expect(() => CredentialMapper.toUniformCredential(jwtVc)).toThrowError(
       `Inconsistent expiration dates between JWT claim (${new Date(
         parseInt(jwtVc['exp' as keyof IVerifiableCredential] as string)
-      ).toISOString()}) and VC value (${(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).credentialSubject.expirationDate})`
+      ).toISOString()}) and VC value (${(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).expirationDate})`
     )
   })
 
@@ -79,9 +80,9 @@ describe('Uniform VC claims', () => {
 
   it('should set credentialSubject.id if sub is present in JWT vc', () => {
     const jwtVc: IVerifiableCredential = getFileAsJson('packages/ssi-types/__tests__/vc_vp_examples/vp/vp_general.json').verifiableCredential[0]
-    jwtVc['sub' as keyof IVerifiableCredential] = (<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).credentialSubject.id
+    jwtVc['sub' as keyof IVerifiableCredential] = (<ICredentialSubject>(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).credentialSubject).id
     const vc = CredentialMapper.toUniformCredential(jwtVc)
-    expect(vc.credentialSubject.id).toEqual(jwtVc['sub' as keyof IVerifiableCredential])
+    expect(!Array.isArray(vc.credentialSubject) && vc.credentialSubject.id).toEqual(jwtVc['sub' as keyof IVerifiableCredential])
   })
 
   it('should throw an error if credentialSubject.id and sub are different in JWT vc', () => {
@@ -89,7 +90,7 @@ describe('Uniform VC claims', () => {
     jwtVc['sub' as keyof IVerifiableCredential] = 'did:test:123'
     expect(() => CredentialMapper.toUniformCredential(jwtVc)).toThrowError(
       `Inconsistent credential subject ids between JWT claim (${jwtVc['sub' as keyof IVerifiableCredential]}) and VC value (${
-        (<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).credentialSubject.id
+        (<ICredentialSubject>(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).credentialSubject).id
       })`
     )
   })
@@ -119,7 +120,8 @@ describe('Uniform VP claims', () => {
     // vp should be decoded
     expect(vp.holder).toEqual('did:example:ebfeb1f712ebc6f1c276e12ec21')
     // vc should be decoded for a uniform vp
-    expect((vp.verifiableCredential[0] as IVerifiableCredential).credentialSubject.degree.type).toEqual('BachelorDegree')
+    const vc = vp.verifiableCredential[0] as IVerifiableCredential
+    expect(!Array.isArray(vc.credentialSubject) && vc.credentialSubject.degree.type).toEqual('BachelorDegree')
   })
 
   it('JWT Decoded VP should populate response', () => {
@@ -129,7 +131,8 @@ describe('Uniform VP claims', () => {
     // vp should be decoded
     expect(vp.holder).toEqual('did:example:ebfeb1f712ebc6f1c276e12ec21')
     // vc should be decoded for a uniform vp
-    expect((vp.verifiableCredential[0] as IVerifiableCredential).credentialSubject.degree.type).toEqual('BachelorDegree')
+    const vc = vp.verifiableCredential[0] as IVerifiableCredential
+    expect(!Array.isArray(vc.credentialSubject) && vc.credentialSubject.degree.type).toEqual('BachelorDegree')
   })
 
   it('JSON-LD VP String should populate response', () => {

--- a/packages/ssi-types/__tests__/wrapped-claims.test.ts
+++ b/packages/ssi-types/__tests__/wrapped-claims.test.ts
@@ -35,7 +35,6 @@ describe('Wrapped VC claims', () => {
 
   it('should throw an error if expiration date and exp are different in JWT vc', () => {
     const jwtVc: IVerifiableCredential = getFileAsJson('packages/ssi-types/__tests__/vc_vp_examples/vp/vp_general.json').verifiableCredential[0]
-    const subject = <ICredentialSubject>jwtVc['vc' as keyof IVerifiableCredential].credentialSubject
     jwtVc['exp' as keyof IVerifiableCredential] = (+new Date()).toString()
     ;(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).expirationDate = (+new Date(
       (jwtVc['exp' as keyof IVerifiableCredential] as string) + 2

--- a/packages/ssi-types/src/mapper/credential-mapper.ts
+++ b/packages/ssi-types/src/mapper/credential-mapper.ts
@@ -188,20 +188,15 @@ export class CredentialMapper {
     // Since this is a credential, we delete any proof just to be sure (should not occur on JWT, but better safe than sorry)
     delete credential.proof
 
-    const subjects = Array.isArray(credential.credentialSubject) ? credential.credentialSubject : [credential.credentialSubject]
     if (decoded.exp) {
-      for (let i = 0; i < subjects.length; i++) {
-        const expDate = subjects[i].expirationDate
-        const jwtExp = parseInt(decoded.exp.toString())
-        // fix seconds to millisecs for the date
-        const expDateAsStr = jwtExp < 9999999999 ? new Date(jwtExp * 1000).toISOString().replace(/\.000Z/, 'Z') : new Date(jwtExp).toISOString()
-        if (expDate && expDate !== expDateAsStr) {
-          throw new Error(`Inconsistent expiration dates between JWT claim (${expDateAsStr}) and VC value (${expDate})`)
-        }
-        Array.isArray(credential.credentialSubject)
-          ? (credential.credentialSubject[i].expirationDate = expDateAsStr)
-          : (credential.credentialSubject.expirationDate = expDateAsStr)
+      const expDate = credential.expirationDate
+      const jwtExp = parseInt(decoded.exp.toString())
+      // fix seconds to millisecs for the date
+      const expDateAsStr = jwtExp < 9999999999 ? new Date(jwtExp * 1000).toISOString().replace(/\.000Z/, 'Z') : new Date(jwtExp).toISOString()
+      if (expDate && expDate !== expDateAsStr) {
+        throw new Error(`Inconsistent expiration dates between JWT claim (${expDateAsStr}) and VC value (${expDate})`)
       }
+      credential.expirationDate = expDateAsStr
     }
 
     if (decoded.nbf) {
@@ -232,6 +227,7 @@ export class CredentialMapper {
     }
 
     if (decoded.sub) {
+      const subjects = Array.isArray(credential.credentialSubject) ? credential.credentialSubject : [credential.credentialSubject]
       for (let i = 0; i < subjects.length; i++) {
         const csId = subjects[i].id
         if (csId && csId !== decoded.sub) {

--- a/packages/ssi-types/src/types/vc.ts
+++ b/packages/ssi-types/src/types/vc.ts
@@ -3,23 +3,25 @@ import { IProofPurpose, IProofType } from './did'
 
 export type AdditionalClaims = Record<string, any>
 
+export type IIssuerId = string
+
 export interface ICredential {
-  // If exp is present, the UNIX timestamp MUST be converted to an [XMLSCHEMA11-2] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.
-  expirationDate?: string
+  '@context': ICredentialContextType | ICredentialContextType[]
+  type: string[]
+  credentialSchema?: undefined | ICredentialSchemaType | ICredentialSchemaType[]
   // If iss is present, the value MUST be used to set the issuer property of the new credential JSON object or the holder property of the new presentation JSON object.
-  issuer: string | IIssuer
+  issuer: IIssuerId | IIssuer
   // If nbf is present, the UNIX timestamp MUST be converted to an [XMLSCHEMA11-2] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.
   issuanceDate: string
   // If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new credential JSON object.
-  credentialSubject: ICredentialSubject & AdditionalClaims
+  credentialSubject: (ICredentialSubject & AdditionalClaims) | (ICredentialSubject & AdditionalClaims)[]
+  // If exp is present, the UNIX timestamp MUST be converted to an [XMLSCHEMA11-2] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.
+  expirationDate?: string
   // If jti is present, the value MUST be used to set the value of the id property of the new JSON object.
   id?: string
-  '@context': ICredentialContextType[] | ICredentialContextType
   credentialStatus?: ICredentialStatus
-  credentialSchema?: undefined | ICredentialSchemaType | ICredentialSchemaType[]
   description?: string
   name?: string
-  type: string[]
 
   [x: string]: any
 }


### PR DESCRIPTION
- Allow to have multiple subjects in a Credential, according to VC Data Model spec.
- Fix bug where expirationDate was made part of the subject, whilst it is part of the credential metadata itself