### PR TITLE
Feature/ssi types/add syntactic sugar

### DIFF
--- a/packages/ssi-types/src/mapper/credential-mapper.ts
+++ b/packages/ssi-types/src/mapper/credential-mapper.ts
@@ -66,6 +66,7 @@ export class CredentialMapper {
       presentation: {
         ...vp,
         verifiableCredential: vcs, // We overwrite the credentials with wrapped versions, making it an InternalVerifiablePresentation. Note: we keep the singular key name of the vc data model
+        type: vp.type? vp.type: vp['@type']
       },
       vcs,
     }

--- a/packages/ssi-types/src/types/vc.ts
+++ b/packages/ssi-types/src/types/vc.ts
@@ -5,7 +5,7 @@ export type AdditionalClaims = Record<string, any>
 
 export type IIssuerId = string
 
-export interface ICredential {
+export interface ICredentialWithType {
   '@context': ICredentialContextType | ICredentialContextType[]
   type: string[]
   credentialSchema?: undefined | ICredentialSchemaType | ICredentialSchemaType[]
@@ -19,12 +19,37 @@ export interface ICredential {
   expirationDate?: string
   // If jti is present, the value MUST be used to set the value of the id property of the new JSON object.
   id?: string
+  '@id'?: string
   credentialStatus?: ICredentialStatus
   description?: string
   name?: string
 
   [x: string]: any
 }
+
+export interface ICredentialWithAtType {
+  '@context': ICredentialContextType | ICredentialContextType[]
+  '@type': string[]
+  credentialSchema?: undefined | ICredentialSchemaType | ICredentialSchemaType[]
+  // If iss is present, the value MUST be used to set the issuer property of the new credential JSON object or the holder property of the new presentation JSON object.
+  issuer: IIssuerId | IIssuer
+  // If nbf is present, the UNIX timestamp MUST be converted to an [XMLSCHEMA11-2] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.
+  issuanceDate: string
+  // If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new credential JSON object.
+  credentialSubject: (ICredentialSubject & AdditionalClaims) | (ICredentialSubject & AdditionalClaims)[]
+  // If exp is present, the UNIX timestamp MUST be converted to an [XMLSCHEMA11-2] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.
+  expirationDate?: string
+  // If jti is present, the value MUST be used to set the value of the id property of the new JSON object.
+  id?: string
+  '@id'?: string
+  credentialStatus?: ICredentialStatus
+  description?: string
+  name?: string
+
+  [x: string]: any
+}
+
+export type ICredential = ICredentialWithType | ICredentialWithAtType
 
 export interface ICredentialSubject {
   id?: string
@@ -88,8 +113,9 @@ export type CompactJWT = string
  */
 export type W3CVerifiableCredential = IVerifiableCredential | CompactJWT
 
-export interface IPresentation {
+export interface IPresentationWithType {
   id?: string
+  '@id'?: string
   '@context': ICredentialContextType | ICredentialContextType[]
   type: string[]
   verifiableCredential: W3CVerifiableCredential[] // we relax to ICredential for internal decoded stable representations without proofs
@@ -98,6 +124,20 @@ export interface IPresentation {
 
   [x: string]: any
 }
+
+export interface IPresentationWithAtType {
+  id?: string
+  '@id'?: string
+  '@context': ICredentialContextType | ICredentialContextType[]
+  '@type': string[]
+  verifiableCredential: W3CVerifiableCredential[] // we relax to ICredential for internal decoded stable representations without proofs
+  presentation_submission?: PresentationSubmission
+  holder?: string
+
+  [x: string]: any
+}
+
+export type IPresentation = IPresentationWithType | IPresentationWithAtType
 
 export type IVerifiablePresentation = IPresentation & IHasProof
 

--- a/packages/ssi-types/src/types/vc.ts
+++ b/packages/ssi-types/src/types/vc.ts
@@ -5,51 +5,36 @@ export type AdditionalClaims = Record<string, any>
 
 export type IIssuerId = string
 
-export interface ICredentialWithType {
+export interface ICredentialWithoutType {
   '@context': ICredentialContextType | ICredentialContextType[]
+  credentialSchema?: undefined | ICredentialSchemaType | ICredentialSchemaType[]
+  // If iss is present, the value MUST be used to set the issuer property of the new credential JSON object or the holder property of the new presentation JSON object.
+  issuer: IIssuerId | IIssuer
+  // If nbf is present, the UNIX timestamp MUST be converted to an [XMLSCHEMA11-2] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.
+  issuanceDate: string
+  // If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new credential JSON object.
+  credentialSubject: (ICredentialSubject & AdditionalClaims) | (ICredentialSubject & AdditionalClaims)[]
+  // If exp is present, the UNIX timestamp MUST be converted to an [XMLSCHEMA11-2] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.
+  expirationDate?: string
+  // If jti is present, the value MUST be used to set the value of the id property of the new JSON object.
+  id?: string
+  '@id'?: string
+  credentialStatus?: ICredentialStatus
+  description?: string
+  name?: string
+
+  [x: string]: any
+}
+
+export interface VerifiableDataTypeProperty {
   type: string[]
-  credentialSchema?: undefined | ICredentialSchemaType | ICredentialSchemaType[]
-  // If iss is present, the value MUST be used to set the issuer property of the new credential JSON object or the holder property of the new presentation JSON object.
-  issuer: IIssuerId | IIssuer
-  // If nbf is present, the UNIX timestamp MUST be converted to an [XMLSCHEMA11-2] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.
-  issuanceDate: string
-  // If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new credential JSON object.
-  credentialSubject: (ICredentialSubject & AdditionalClaims) | (ICredentialSubject & AdditionalClaims)[]
-  // If exp is present, the UNIX timestamp MUST be converted to an [XMLSCHEMA11-2] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.
-  expirationDate?: string
-  // If jti is present, the value MUST be used to set the value of the id property of the new JSON object.
-  id?: string
-  '@id'?: string
-  credentialStatus?: ICredentialStatus
-  description?: string
-  name?: string
-
-  [x: string]: any
 }
 
-export interface ICredentialWithAtType {
-  '@context': ICredentialContextType | ICredentialContextType[]
+export interface VerifiableDataAtTypeProperty {
   '@type': string[]
-  credentialSchema?: undefined | ICredentialSchemaType | ICredentialSchemaType[]
-  // If iss is present, the value MUST be used to set the issuer property of the new credential JSON object or the holder property of the new presentation JSON object.
-  issuer: IIssuerId | IIssuer
-  // If nbf is present, the UNIX timestamp MUST be converted to an [XMLSCHEMA11-2] date-time, and MUST be used to set the value of the issuanceDate property of the new JSON object.
-  issuanceDate: string
-  // If sub is present, the value MUST be used to set the value of the id property of credentialSubject of the new credential JSON object.
-  credentialSubject: (ICredentialSubject & AdditionalClaims) | (ICredentialSubject & AdditionalClaims)[]
-  // If exp is present, the UNIX timestamp MUST be converted to an [XMLSCHEMA11-2] date-time, and MUST be used to set the value of the expirationDate property of credentialSubject of the new JSON object.
-  expirationDate?: string
-  // If jti is present, the value MUST be used to set the value of the id property of the new JSON object.
-  id?: string
-  '@id'?: string
-  credentialStatus?: ICredentialStatus
-  description?: string
-  name?: string
-
-  [x: string]: any
 }
 
-export type ICredential = ICredentialWithType | ICredentialWithAtType
+export type ICredential = ICredentialWithoutType & (VerifiableDataAtTypeProperty | VerifiableDataTypeProperty)
 
 export interface ICredentialSubject {
   id?: string
@@ -113,11 +98,10 @@ export type CompactJWT = string
  */
 export type W3CVerifiableCredential = IVerifiableCredential | CompactJWT
 
-export interface IPresentationWithType {
+export interface IPresentationWithoutType {
   id?: string
   '@id'?: string
   '@context': ICredentialContextType | ICredentialContextType[]
-  type: string[]
   verifiableCredential: W3CVerifiableCredential[] // we relax to ICredential for internal decoded stable representations without proofs
   presentation_submission?: PresentationSubmission
   holder?: string
@@ -125,19 +109,7 @@ export interface IPresentationWithType {
   [x: string]: any
 }
 
-export interface IPresentationWithAtType {
-  id?: string
-  '@id'?: string
-  '@context': ICredentialContextType | ICredentialContextType[]
-  '@type': string[]
-  verifiableCredential: W3CVerifiableCredential[] // we relax to ICredential for internal decoded stable representations without proofs
-  presentation_submission?: PresentationSubmission
-  holder?: string
-
-  [x: string]: any
-}
-
-export type IPresentation = IPresentationWithType | IPresentationWithAtType
+export type IPresentation = IPresentationWithoutType & (VerifiableDataTypeProperty | VerifiableDataAtTypeProperty)
 
 export type IVerifiablePresentation = IPresentation & IHasProof
 


### PR DESCRIPTION
reading Gaia-X docs, I've noticed a slight difference between our types and Gaia-X examples. So I went back to vc-data-model and found [this](https://www.w3.org/TR/vc-data-model/#syntactic-sugar) section.
This PR covers the first bullet point of the section above.