### PR TITLE
feat(ssi-types): add kid to cnf

### DIFF
--- a/packages/ssi-types/src/types/sd-jwt-vc.ts
+++ b/packages/ssi-types/src/types/sd-jwt-vc.ts
@@ -25,7 +25,7 @@ export interface SdJwtDecodedVerifiableCredentialPayload {
   exp?: number
   cnf?: {
     jwk?: any
-    // TODO: add other cnf properties
+    kid?: string
   }
   status?: {
     idx: number


### PR DESCRIPTION
Small update to support `kid` in an sd-jwt `cnf` claim, allowing the sd-jwt to be bound to a did in addition to the already supported `jwk`