### PR TITLE
feature/SDK-11 fixing inconsistency between UniRegistrar and ssi-sdk deactivation did function

### DIFF
--- a/packages/uni-resolver-registrar-api/src/api-functions.ts
+++ b/packages/uni-resolver-registrar-api/src/api-functions.ts
@@ -9,6 +9,7 @@ import { v4 } from 'uuid'
 import {
   CreateState,
   DidRegistrationCreateRequest,
+  DidRegistrationDeactivateRequest,
   DidStateValue,
   ICreateDidEndpointOpts,
   IGlobalDidWebEndpointOpts,
@@ -167,7 +168,13 @@ export function resolveDidEndpoint(router: Router, context: IRequiredContext, op
   })
 }
 
-export function deactivateDidEndpoint(router: Router, context: IRequiredContext, opts?: ISingleEndpointOpts) {
+/**
+ * @deprecated
+ * @param router
+ * @param context
+ * @param opts
+ */
+export function deleteDidEndpoint(router: Router, context: IRequiredContext, opts?: ISingleEndpointOpts) {
   if (opts?.enabled === false) {
     console.log(`Deactivate DID endpoint is disabled`)
     return
@@ -187,6 +194,41 @@ export function deactivateDidEndpoint(router: Router, context: IRequiredContext,
       return response.send()
     } catch (e) {
       return sendErrorResponse(response, 500, e.message as string, e)
+    }
+  })
+}
+
+export function deactivateDidEndpoint(router: Router, context: IRequiredContext, opts?: ISingleEndpointOpts) {
+  if (opts?.enabled === false) {
+    console.log('Deactivate DID endpoint is disabled')
+    return
+  }
+
+  router.post(opts?.path ?? '/deactivate', checkAuth(opts?.endpoint), async (request: Request, response: Response) => {
+    try {
+      const deactivateRequest: DidRegistrationDeactivateRequest = request.body
+      if (!deactivateRequest) {
+        return sendErrorResponse(response, 400, 'Invalid request body', { state: 'failed' })
+      }
+
+      const { did, jobId = v4() } = deactivateRequest
+      if (!did) {
+        return sendErrorResponse(response, 400, 'No DID provided', { state: 'failed' })
+      }
+
+      const result = await context.agent.didManagerDelete({ did })
+      if (!result) {
+        return sendErrorResponse(response, 404, `DID ${did} not found`, { state: 'failed' })
+      }
+
+      response.status(200).json({
+        state: 'finished',
+        did,
+        jobId,
+      })
+      return response.send()
+    } catch (e) {
+      return sendErrorResponse(response, 500, e.message as string, { state: 'failed', errorDetails: e })
     }
   })
 }

--- a/packages/uni-resolver-registrar-api/src/api-functions.ts
+++ b/packages/uni-resolver-registrar-api/src/api-functions.ts
@@ -169,7 +169,6 @@ export function resolveDidEndpoint(router: Router, context: IRequiredContext, op
 }
 
 /**
- * @deprecated
  * @param router
  * @param context
  * @param opts

--- a/packages/uni-resolver-registrar-api/src/types.ts
+++ b/packages/uni-resolver-registrar-api/src/types.ts
@@ -25,9 +25,9 @@ export interface DidRegistrationUpdateRequest {
 
 export interface DidRegistrationDeactivateRequest {
   did: string
-  jobId: string
-  options: DidRegistrationOptions
-  secret: DidRegistrationSecret
+  jobId?: string
+  options?: DidRegistrationOptions
+  secret?: DidRegistrationSecret
 }
 
 export type DidDocumentOperation = 'setDidDocument' | 'addToDidDocument' | 'removeFromDidDocument' | string

--- a/packages/uni-resolver-registrar-api/src/uni-resolver-api-server.ts
+++ b/packages/uni-resolver-registrar-api/src/uni-resolver-api-server.ts
@@ -3,7 +3,7 @@ import { copyGlobalAuthToEndpoints, ExpressSupport } from '@sphereon/ssi-express
 import { TAgent } from '@veramo/core'
 
 import express, { Express, Router } from 'express'
-import { createDidEndpoint, deactivateDidEndpoint, getDidMethodsEndpoint, resolveDidEndpoint } from './api-functions'
+import { createDidEndpoint, deleteDidEndpoint, deactivateDidEndpoint, getDidMethodsEndpoint, resolveDidEndpoint } from './api-functions'
 import { IDidAPIOpts, IRequiredPlugins } from './types'
 
 export class UniResolverApiServer {
@@ -34,7 +34,8 @@ export class UniResolverApiServer {
     }
     if (features.includes('did-persist')) {
       createDidEndpoint(this.router, context, opts?.endpointOpts?.createDid)
-      deactivateDidEndpoint(this.router, context, opts?.endpointOpts?.deactivateDid) // not in spec.
+      deleteDidEndpoint(this.router, context, opts?.endpointOpts?.deactivateDid) // not in spec.
+      deactivateDidEndpoint(this.router, context, opts?.endpointOpts?.deactivateDid)
     }
     this._express.use(opts?.endpointOpts?.basePath ?? '', this.router)
   }


### PR DESCRIPTION
added:
- deactivateDidEndpoint function according to decentralized)-identity's universal-registrar
changed:
- renamed previous method as deleteDidEndpoint and marked it as deprecated