### PR TITLE
fix: remove execution of loading env files

### DIFF
--- a/packages/ssi-express-support/src/index.ts
+++ b/packages/ssi-express-support/src/index.ts
@@ -1,5 +1,3 @@
-import * as dotenv from 'dotenv-flow'
-dotenv.config()
 export * from './entra-id-auth'
 export * from './static-bearer-auth'
 export * from './auth-utils'


### PR DESCRIPTION
Loading the env variables inside the express support package can cause side effects when you want to load the variables at an earlier point and use them for validation. Then you get warnings like:
```
dotenv-flow: "PORT" is already defined in `process.env` and will not be overwritten
dotenv-flow: "NODE_ENV" is already defined in `process.env` and will not be overwritten
```

I would prefer that I am able to load my own variables inside, there could be the case that I don't want the .env file included, but e.g. `example.env`, but it will because of the express package.