### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,45 +1,18 @@
 {
   "targetDefaults": {
-    "build": {
-      "cache": true,
-      "dependsOn": ["^build"],
-      "outputs": ["{projectRoot}/coverage"]
-    },
-    "build:clean": {
-      "dependsOn": []
-    },
-    "start:prod": {
-      "dependsOn": ["build"]
-    },
-    "start:dev": {
-      "dependsOn": []
-    },
-    "generate-plugin-schema": {
-      "dependsOn": []
-    },
-    "typeorm": {
-      "dependsOn": []
-    },
-    "typeorm-sqlite:migration:generate": {
-      "dependsOn": []
-    },
-    "typeorm-sqlite:migration:run": {
-      "dependsOn": []
-    },
-    "typeorm-postgres:migration:generate": {
-      "dependsOn": []
-    },
-    "typeorm-postgres:migration:run": {
-      "dependsOn": []
-    },
-    "build:copyfilesdis": {
-      "dependsOn": []
-    },
-    "start:energyshr": {
-      "dependsOn": []
-    },
-    "start:dev2": {
-      "dependsOn": []
-    }
-  }
+    "build": { "cache": true, "dependsOn": ["^build"], "outputs": ["{projectRoot}/coverage"] },
+    "build:clean": { "dependsOn": [] },
+    "start:prod": { "dependsOn": ["build"] },
+    "start:dev": { "dependsOn": [] },
+    "generate-plugin-schema": { "dependsOn": [] },
+    "typeorm": { "dependsOn": [] },
+    "typeorm-sqlite:migration:generate": { "dependsOn": [] },
+    "typeorm-sqlite:migration:run": { "dependsOn": [] },
+    "typeorm-postgres:migration:generate": { "dependsOn": [] },
+    "typeorm-postgres:migration:run": { "dependsOn": [] },
+    "build:copyfilesdis": { "dependsOn": [] },
+    "start:energyshr": { "dependsOn": [] },
+    "start:dev2": { "dependsOn": [] }
+  },
+  "nxCloudId": "66ff23d99fb700eb0f2270df"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/66ff236ce701a83caf24f7d4/workspaces/66ff23d99fb700eb0f2270df

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.