### PR TITLE
feat: mdoc device response multiple documents

### DIFF
--- a/packages/ssi-types/__tests__/uniform-claims.test.ts
+++ b/packages/ssi-types/__tests__/uniform-claims.test.ts
@@ -139,7 +139,6 @@ describe('Uniform VC claims', () => {
   it('should work with sd jwt VC from Funke', () => {
     const jwtVc: string = getFile('packages/ssi-types/__tests__/vc_vp_examples/vc/sd.jwt')
     const vc = CredentialMapper.toUniformCredential(jwtVc, { hasher: generateDigest })
-    console.log(JSON.stringify(vc, null, 2))
     expect(vc.issuanceDate).toEqual('2024-08-16T09:29:44Z')
     expect(vc.expirationDate).toEqual('2024-08-30T09:29:44Z')
   })
@@ -147,7 +146,6 @@ describe('Uniform VC claims', () => {
   it('should work with issuer signed (mdoc) VC from Funke', () => {
     const issuerSigned: string = getFile('packages/ssi-types/__tests__/vc_vp_examples/vc/funke.issuersigned')
     const vc = CredentialMapper.toUniformCredential(issuerSigned)
-    console.log(JSON.stringify(vc, null, 2))
     expect(vc.issuanceDate).toEqual('2024-08-12T09:54:45Z')
     expect(vc.expirationDate).toEqual('2024-08-26T09:54:45Z')
   })
@@ -155,7 +153,6 @@ describe('Uniform VC claims', () => {
   it('should work with sd jwt VC from Animo', () => {
     const jwtVc: string = getFile('packages/ssi-types/__tests__/vc_vp_examples/vc/animo.sd.jwt')
     const vc = CredentialMapper.toUniformCredential(jwtVc, { hasher: generateDigest })
-    console.log(JSON.stringify(vc, null, 2))
     expect(vc.issuanceDate).toEqual('2024-08-26T00:06:09Z')
   })
 })

--- a/packages/ssi-types/src/mapper/credential-mapper.ts
+++ b/packages/ssi-types/src/mapper/credential-mapper.ts
@@ -162,19 +162,19 @@ export class CredentialMapper {
         deviceResponse = originalPresentation
       }
 
-      const mdocCredential = deviceResponse.documents
+      const mdocCredentials = deviceResponse.documents
         ?.map((doc) => CredentialMapper.toWrappedVerifiableCredential(doc, opts) as WrappedMdocCredential)
-        .find((value) => value !== undefined)
-      if (mdocCredential === undefined) {
-        throw Error('mdoc credential data corruption')
+      if (!mdocCredentials || mdocCredentials.length === 0 ) {
+        throw new Error('could not extract any mdoc credentials from mdoc device response')
       }
+      
       return {
         type: CredentialMapper.isMsoMdocDecodedPresentation(originalPresentation) ? OriginalType.MSO_MDOC_DECODED : OriginalType.MSO_MDOC_ENCODED,
         format: 'mso_mdoc',
         original: originalPresentation,
         presentation: deviceResponse,
         decoded: deviceResponse,
-        vcs: [mdocCredential],
+        vcs: mdocCredentials,
       }
     }
     // SD-JWT

--- a/packages/ssi-types/src/types/mso_mdoc.ts
+++ b/packages/ssi-types/src/types/mso_mdoc.ts
@@ -75,9 +75,10 @@ export interface WrappedMdocPresentation {
    */
   presentation: MdocDeviceResponse
   /**
-   * Wrapped Mdocs belonging to the Presentation. .
+   * Wrapped Mdocs belonging to the Presentation. There can be multiple
+   * documents in a single device response
    */
-  vcs: [WrappedMdocCredential]
+  vcs: WrappedMdocCredential[]
 }
 
 export function isWrappedMdocCredential(vc: WrappedVerifiableCredential): vc is WrappedMdocCredential {


### PR DESCRIPTION
Extract all documents from an mdoc device response instead of one. Will also make a PR in PEX to correctly extract the correct document from a device response if it contains mulitple documents.

Not really a breaking change as it first was an array with one entry and now an array with multiple entries