### PR TITLE
fixes/SDK-43_hasher-for-sd-jwt

### DIFF
--- a/packages/siopv2-oid4vp-op-auth/src/session/OpSession.ts
+++ b/packages/siopv2-oid4vp-op-auth/src/session/OpSession.ts
@@ -213,6 +213,10 @@ export class OpSession {
   }
 
   public async getOID4VP(args: IOpSessionGetOID4VPArgs): Promise<OID4VP> {
+    if (args.hasher && !this.options.hasher) {
+      // capture hasher when possible and not present, can be useful for existing implementations
+      this.options.hasher = args.hasher
+    }
     return await OID4VP.init(this, args.allIdentifiers ?? [], args.hasher)
   }
 
@@ -302,7 +306,6 @@ export class OpSession {
     const verification: Verification = {
       presentationVerificationCallback: this.createPresentationVerificationCallback(this.context),
     }
-
     const request = await this.getAuthorizationRequest()
     const hasDefinitions = await this.hasPresentationDefinitions()
     if (hasDefinitions) {
@@ -310,7 +313,7 @@ export class OpSession {
         return sum + pd.definition.input_descriptors.length
       }, 0)
       const totalVCs = args.verifiablePresentations?.reduce((sum, vp) => {
-        const uvp = CredentialMapper.toUniformPresentation(vp)
+        const uvp = CredentialMapper.toUniformPresentation(vp, { hasher: args.hasher ?? this.options.hasher })
         return sum + (uvp.verifiableCredential?.length ?? 0)
       }, 0)
 

--- a/packages/siopv2-oid4vp-op-auth/src/session/OpSession.ts
+++ b/packages/siopv2-oid4vp-op-auth/src/session/OpSession.ts
@@ -19,6 +19,7 @@ import { encodeBase64url } from '@sphereon/ssi-sdk.core'
 import {
   CompactSdJwtVc,
   CredentialMapper,
+  Hasher,
   OriginalVerifiableCredential,
   parseDid,
   PresentationSubmission,
@@ -316,7 +317,7 @@ export class OpSession {
       const totalInputDescriptors = request.presentationDefinitions?.reduce((sum, pd) => {
         return sum + pd.definition.input_descriptors.length
       }, 0)
-      const totalVCs = this.countVCsInAllVPs(args)
+      const totalVCs = this.countVCsInAllVPs(args.verifiablePresentations, args.hasher)
 
       if (!request.presentationDefinitions || !args.verifiablePresentations || totalVCs !== totalInputDescriptors) {
         throw Error(
@@ -366,9 +367,9 @@ export class OpSession {
     }
   }
 
-  private countVCsInAllVPs(args: IOpsSendSiopAuthorizationResponseArgs) {
-    return args.verifiablePresentations?.reduce((sum, vp) => {
-      const uvp = CredentialMapper.toUniformPresentation(vp, { hasher: args.hasher ?? this.options.hasher })
+  private countVCsInAllVPs(verifiablePresentations: W3CVerifiablePresentation[] | undefined, hasher: Hasher | undefined) {
+    return verifiablePresentations?.reduce((sum, vp) => {
+      const uvp = CredentialMapper.toUniformPresentation(vp, { hasher: hasher ?? this.options.hasher })
       if (uvp.verifiableCredential?.length) {
         return sum + uvp.verifiableCredential?.length
       }

--- a/packages/siopv2-oid4vp-op-auth/src/session/OpSession.ts
+++ b/packages/siopv2-oid4vp-op-auth/src/session/OpSession.ts
@@ -213,10 +213,6 @@ export class OpSession {
   }
 
   public async getOID4VP(args: IOpSessionGetOID4VPArgs): Promise<OID4VP> {
-    if (args.hasher && !this.options.hasher) {
-      // capture hasher when possible and not present, can be useful for existing implementations
-      this.options.hasher = args.hasher
-    }
     return await OID4VP.init(this, args.allIdentifiers ?? [], args.hasher)
   }
 

--- a/packages/siopv2-oid4vp-op-auth/src/session/OpSession.ts
+++ b/packages/siopv2-oid4vp-op-auth/src/session/OpSession.ts
@@ -376,7 +376,7 @@ export class OpSession {
       if (!PEX.allowMultipleVCsPerPresentation(uvp.verifiableCredential as Array<OriginalVerifiableCredential>)) {
         return sum + 1
       }
-      return 0
+      return sum
     }, 0)
   }
 }

--- a/packages/siopv2-oid4vp-op-auth/src/session/OpSession.ts
+++ b/packages/siopv2-oid4vp-op-auth/src/session/OpSession.ts
@@ -317,7 +317,7 @@ export class OpSession {
       const totalInputDescriptors = request.presentationDefinitions?.reduce((sum, pd) => {
         return sum + pd.definition.input_descriptors.length
       }, 0)
-      const totalVCs = this.countVCsInAllVPs(args.verifiablePresentations, args.hasher)
+      const totalVCs = args.verifiablePresentations ? this.countVCsInAllVPs(args.verifiablePresentations, args.hasher) : 0
 
       if (!request.presentationDefinitions || !args.verifiablePresentations || totalVCs !== totalInputDescriptors) {
         throw Error(
@@ -367,8 +367,8 @@ export class OpSession {
     }
   }
 
-  private countVCsInAllVPs(verifiablePresentations: W3CVerifiablePresentation[] | undefined, hasher: Hasher | undefined) {
-    return verifiablePresentations?.reduce((sum, vp) => {
+  private countVCsInAllVPs(verifiablePresentations: W3CVerifiablePresentation[], hasher?: Hasher) {
+    return verifiablePresentations.reduce((sum, vp) => {
       const uvp = CredentialMapper.toUniformPresentation(vp, { hasher: hasher ?? this.options.hasher })
       if (uvp.verifiableCredential?.length) {
         return sum + uvp.verifiableCredential?.length

--- a/packages/siopv2-oid4vp-op-auth/src/session/OpSession.ts
+++ b/packages/siopv2-oid4vp-op-auth/src/session/OpSession.ts
@@ -314,7 +314,7 @@ export class OpSession {
       }, 0)
       const totalVCs = args.verifiablePresentations?.reduce((sum, vp) => {
         const uvp = CredentialMapper.toUniformPresentation(vp, { hasher: args.hasher ?? this.options.hasher })
-        return sum + (uvp.verifiableCredential?.length ?? 0)
+        return sum + ((uvp.verifiableCredential?.length ?? CredentialMapper.isSdJwtDecodedCredential(uvp)) ? 1 : 0)
       }, 0)
 
       if (!request.presentationDefinitions || !args.verifiablePresentations || totalVCs !== totalInputDescriptors) {

--- a/packages/siopv2-oid4vp-op-auth/src/types/IDidAuthSiopOpAuthenticator.ts
+++ b/packages/siopv2-oid4vp-op-auth/src/types/IDidAuthSiopOpAuthenticator.ts
@@ -122,6 +122,7 @@ export interface IOpsSendSiopAuthorizationResponseArgs {
   // verifiedAuthorizationRequest: VerifiedAuthorizationRequest
   presentationSubmission?: PresentationSubmission
   verifiablePresentations?: W3CVerifiablePresentation[]
+  hasher?: Hasher
 }
 
 export enum events {
@@ -158,6 +159,7 @@ export interface IOPOptions {
   presentationSignCallback?: PresentationSignCallback
 
   resolveOpts?: ResolveOpts
+  hasher?: Hasher
 }
 
 /*

--- a/packages/ssi-types/src/mapper/credential-mapper.ts
+++ b/packages/ssi-types/src/mapper/credential-mapper.ts
@@ -162,12 +162,13 @@ export class CredentialMapper {
         deviceResponse = originalPresentation
       }
 
-      const mdocCredentials = deviceResponse.documents
-        ?.map((doc) => CredentialMapper.toWrappedVerifiableCredential(doc, opts) as WrappedMdocCredential)
-      if (!mdocCredentials || mdocCredentials.length === 0 ) {
+      const mdocCredentials = deviceResponse.documents?.map(
+        (doc) => CredentialMapper.toWrappedVerifiableCredential(doc, opts) as WrappedMdocCredential
+      )
+      if (!mdocCredentials || mdocCredentials.length === 0) {
         throw new Error('could not extract any mdoc credentials from mdoc device response')
       }
-      
+
       return {
         type: CredentialMapper.isMsoMdocDecodedPresentation(originalPresentation) ? OriginalType.MSO_MDOC_DECODED : OriginalType.MSO_MDOC_ENCODED,
         format: 'mso_mdoc',
@@ -616,7 +617,7 @@ export class CredentialMapper {
 
   static toUniformPresentation(
     presentation: OriginalVerifiablePresentation,
-    opts?: { maxTimeSkewInMS?: number; addContextIfMissing?: boolean }
+    opts?: { maxTimeSkewInMS?: number; addContextIfMissing?: boolean; hasher?: Hasher }
   ): IVerifiablePresentation {
     if (CredentialMapper.isSdJwtDecodedCredential(presentation)) {
       throw new Error('Converting SD-JWT VC to uniform VP is not supported.')
@@ -631,7 +632,7 @@ export class CredentialMapper {
         'Could not determine original presentation, probably it was a converted JWT presentation, that is now missing the JWT value in the proof'
       )
     }
-    const decoded = CredentialMapper.decodeVerifiablePresentation(original)
+    const decoded = CredentialMapper.decodeVerifiablePresentation(original, opts?.hasher)
     const isJwtEncoded: boolean = CredentialMapper.isJwtEncoded(original)
     const isJwtDecoded: boolean = CredentialMapper.isJwtDecodedPresentation(original)
     const uniformPresentation =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1559,37 +1559,6 @@ importers:
         specifier: ^13.5.5
         version: 13.5.5
 
-  packages/oidf-metatdata-server:
-    dependencies:
-      '@sphereon/ssi-express-support':
-        specifier: workspace:*
-        version: link:../ssi-express-support
-      '@sphereon/ssi-sdk.oid4vci-issuer-store':
-        specifier: workspace:*
-        version: link:../oid4vci-issuer-store
-      debug:
-        specifier: ^4.3.5
-        version: 4.3.6
-      express:
-        specifier: ^4.19.2
-        version: 4.21.1
-      semver:
-        specifier: ^7.6.3
-        version: 7.6.3
-    devDependencies:
-      '@sphereon/ssi-sdk.agent-config':
-        specifier: workspace:*
-        version: link:../agent-config
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.21
-      '@types/express-serve-static-core':
-        specifier: ^4.19.5
-        version: 4.19.5
-      '@types/semver':
-        specifier: ^7.5.8
-        version: 7.5.8
-
   packages/pd-manager:
     dependencies:
       '@sphereon/pex':


### PR DESCRIPTION
Due to crash "Hasher implementation is required to decode SD-JWT" in OpSession